### PR TITLE
Fixes the URL parameter for method:by-http-method

### DIFF
--- a/src/main/java/com/amazonaws/services/apigateway/model/Resource.java
+++ b/src/main/java/com/amazonaws/services/apigateway/model/Resource.java
@@ -45,14 +45,14 @@ public interface Resource extends ResourceInfo {
      */
     @Link(relation = "method:by-http-method")
     Method getMethodByHttpMethod(
-        @UriVariable(name = "http_method") String httpMethod);
+        @UriVariable(name = "httpMethod") String httpMethod);
 
     /**
      *
      */
     @Link(relation = "method:put", method = HttpMethodName.PUT)
     Method putMethod(PutMethodInput putMethodInput, 
-        @UriVariable(name = "http_method") String httpMethod);
+        @UriVariable(name = "httpMethod") String httpMethod);
 
     /**
      *


### PR DESCRIPTION
URL parameter for this method is wrong and causes an this exception:

`Invalid Method identifier specified (Service: null; Status Code: 404; Error Code: null; Request ID: 5f90c40f-e6da-11e5-8d28-1f8d3ca25b79)`

I changed the parameter according to the REST documentation:
http://docs.aws.amazon.com/apigateway/api-reference/link-relation/method-by-http-method/
